### PR TITLE
GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      # Check for updates once a week
+      interval: 'weekly'

--- a/.github/workflows/make-publish.yml
+++ b/.github/workflows/make-publish.yml
@@ -26,7 +26,7 @@ jobs:
         asv publish
 
     - name: Update gh-pages branch
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
       with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./html


### PR DESCRIPTION
Pins to commit hashes for third-party actions and adds Dependabot.